### PR TITLE
style: fix padding and adjust submenu offset for FieldShelf dropdown …

### DIFF
--- a/practices/standard/docs/2026-03-20-shelves/goal.md
+++ b/practices/standard/docs/2026-03-20-shelves/goal.md
@@ -8,8 +8,8 @@ status: in-progress
 
 这里是 practices/standard 计划要完成的开发任务:
 [x] 所有的shelfs错误命名改为shelves
-[] measure和dimension shelves, 聚合、编码、数值格式的二级菜单, 需要贴在一级菜单的右侧, 目前它们有重叠, 需要优化.
-[] 二级菜单内有 padding, 导致hover到"求和"时, 背景无法紧贴二级菜单容器的左右侧边界, 需要优化.
+[x] measure和dimension shelves, 聚合、编码、数值格式的二级菜单, 需要贴在一级菜单的右侧, 目前它们有重叠, 需要优化.
+[x] 二级菜单内有 padding, 导致hover到"求和"时, 背景无法紧贴二级菜单容器的左右侧边界, 需要优化.
 [] where的日期筛选面板, 将四种面板放到一个Popover内, 使用Tabs切换.
 
 附录:

--- a/practices/standard/src/components/Shelves/common/FieldShelf.css
+++ b/practices/standard/src/components/Shelves/common/FieldShelf.css
@@ -1,0 +1,9 @@
+.fieldshelf-dropdown .ant-dropdown-menu {
+  padding: 6px 0;
+  overflow: auto;
+}
+
+.fieldshelf-dropdown
+  .ant-dropdown-menu-submenu-title.ant-dropdown-menu-submenu-title {
+  border-radius: 0;
+}

--- a/practices/standard/src/components/Shelves/common/FieldShelf.tsx
+++ b/practices/standard/src/components/Shelves/common/FieldShelf.tsx
@@ -13,6 +13,7 @@ import {
   useShelfItemDropTargets,
 } from '../dnd';
 import { ShelfTrack, type ShelfTone } from './ShelfTrack';
+import './FieldShelf.css';
 
 const REMOVE_ICON_DEFAULT_COLOR = '#8c8c8c';
 const REMOVE_ICON_HOVER_COLOR = '#ff4d4f';
@@ -206,6 +207,7 @@ const FieldShelfTag = <TItem extends FieldShelfItem>(props: {
           trigger={['click']}
           placement="bottom"
           menu={{
+            rootClassName: 'fieldshelf-dropdown',
             items: buildMenuItems(item),
             selectable: true,
             selectedKeys: getMenuSelectedKeys?.(item),

--- a/practices/standard/src/components/Shelves/utils/menuItemUtils.tsx
+++ b/practices/standard/src/components/Shelves/utils/menuItemUtils.tsx
@@ -1,6 +1,6 @@
 import { Flex, Typography } from 'antd';
 
-export const SHELF_MENU_SUBMENU_OFFSET: [number, number] = [-10, -4];
+export const SHELF_MENU_SUBMENU_OFFSET: [number, number] = [0, -6];
 
 export const buildShelfMenuLabel = (label: string, extra?: string) => {
   if (!extra) {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix
- [x] Code style optimization

### 💡 Background and solution

**Problem:**
1. Secondary menus (Aggregate, Encoding, etc.) overlapped with the primary menu.
2. Hover background in secondary menus didn't reach the left/right edges due to internal padding.

**Fix:**
1. Adjusted `SHELF_MENU_SUBMENU_OFFSET` from `[-10, -4]` → `[0, -6]` to fix overlap.
2. Added `FieldShelf.css` to remove horizontal padding from `.ant-dropdown-menu` and reset border-radius on submenu titles, allowing the hover background to fill the full width.

### ☑️ Self-Check before Merge

- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Changelog is provided or not needed

<img width="836" height="727" alt="image" src="https://github.com/user-attachments/assets/4a7fd802-8519-43fb-baa9-4b9f3c92f7dd" />
