### PR TITLE
chore(gitignore): reorganize AI tool ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,10 @@ coverage/
 tools/llm_test/top-key
 tools/llm_test/new-type
 
-
-# Claude
+# AI Tools 
 .claude
-
-# Trae
 .trae
+.codex
 
+# Git
 .worktrees


### PR DESCRIPTION
This PR cleans up .gitignore by grouping AI tool folders together