### PR TITLE
[codex] fix(website): restore source condition resolution

### DIFF
--- a/apps/website/rspress.config.ts
+++ b/apps/website/rspress.config.ts
@@ -130,6 +130,10 @@ export default defineConfig({
           )
           config.externals = [...(Array.isArray(config.externals) ? config.externals : []), 'yjs']
         }
+
+        // The website relies on workspace packages exposing source entries.
+        // Keep the repo-wide source resolution behavior and layer our narrow starter aliases on top.
+        config.resolve.conditionNames = ['source', '...']
       },
     },
     server: {


### PR DESCRIPTION
## Summary

- Restore website Rspack `source` condition resolution while keeping the narrow `vbi-react` starter aliases added in the previous refactor.
- Fix the GitHub Pages deploy failure introduced after #517, where `website build` could no longer resolve workspace packages such as `@visactor/vbi`, `@visactor/vquery`, `@visactor/vseed`, and the practice apps.

## Root Cause

- `apps/website` relies on workspace packages exporting a `source` entry for docs-time source resolution.
- The previous starter/docs fix removed `config.resolve.conditionNames = ["source", "..."]` entirely, which broke `website build` in clean CI and caused the deploy workflow to fail during `Build website`.

## Validation

- Statically verified the failing deploy logs now match the restored source-resolution path.
- Did not rerun full `website build` locally because that command is heavy and previously destabilized the WSL environment.
